### PR TITLE
Fixed PrintMethods(";" was skipped)

### DIFF
--- a/lib/Il2CppHelper.h
+++ b/lib/Il2CppHelper.h
@@ -22,7 +22,7 @@ public:
 	void GetClassesAndNamesFromAssembly(const Il2CppImage* _image);
 
 	void GetFieldsInformation(Il2CppClass* klass);
-	void PrintMethods(Il2CppClass* klass)
+	void PrintMethods(Il2CppClass* klass);
 	void PrintAssemblyMap();
 private:
 	 std::map<const char*, const Il2CppAssembly*> assemblyMap;


### PR DESCRIPTION
Fixed PrintMethods(";" was skipped)